### PR TITLE
Fixes a new display bug in edit field

### DIFF
--- a/client/src/components/bilara-cell.js
+++ b/client/src/components/bilara-cell.js
@@ -45,7 +45,9 @@ div
 
 .string.editable
 {
-  font-family: var(--bilara-serif)
+  font-family: var(--bilara-serif);
+  
+  display: block;
 }
 
 .string.editable:focus


### PR DESCRIPTION
Apparently as a result of recent changes, under certain circumstances the edit field appears with a default size of zero and cannot be clicked. This ensures the edit field is always line height and 100% width.