### PR TITLE
fix: shebangs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 *.gpg
 *.pickle
 local.sh
+.DS_Store

--- a/index-tm
+++ b/index-tm
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd server
 poetry run python -c "from search import search; search.index(force=True)"

--- a/run-dev
+++ b/run-dev
@@ -1,4 +1,4 @@
-#bin/env bash
+#!/usr/bin/env bash
 
 (cd client; npm install)
 

--- a/run-dev-fast
+++ b/run-dev-fast
@@ -1,5 +1,4 @@
-#bin/env bash
-
+#!/usr/bin/env bash
 
 if [ -x "./local.sh" ]; then
 ./local.sh
@@ -7,9 +6,9 @@ fi
 
 export FLASK_ENV=development
 
-(trap 'kill 0' SIGINT; ( 
+(trap 'kill 0' SIGINT; (
 	cd server;
 	poetry run python -c "import arango_common; arango_common.run_migrations()" &&
 	poetry run flask run --port 5000 ) &
-	(cd client; npx es-dev-server ) 
+	(cd client; npx es-dev-server )
 )

--- a/run-prod.sh
+++ b/run-prod.sh
@@ -1,4 +1,4 @@
-#bin/env bash
+#!/usr/bin/env bash
 
 PORT=8081
 PROXY_PORT=9096


### PR DESCRIPTION
On Linux, the most common location of `env` is at `/usr/bin`; on macOS, `/bin/bash` is about 15 years old due to the GPL; and a shebang without the bang is just a comment.